### PR TITLE
Imports command from create-twilio-function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ OPTIONS
 
   --create-environment                     Creates environment if it couldn't find it.
 
-  --cwd=cwd                                Sets the directory of your existing Functions project. Defaults to current
+  --cwd=cwd                                Sets the directory of your existing Serverless project. Defaults to current
                                            directory
 
   --env=env                                Path to .env file for environment variables that should be installed
@@ -84,7 +84,7 @@ OPTIONS
   --source-environment=source-environment  SID or suffix of an existing environment you want to deploy from.
 ```
 
-_See code: [src/commands/serverless/activate.js](https://github.com/twilio-labs/plugin-serverless/blob/v1.0.0-alpha.7/src/commands/serverless/activate.js)_
+_See code: [src/commands/serverless/activate.js](https://github.com/twilio-labs/plugin-serverless/blob/v1.0.0-alpha.9/src/commands/serverless/activate.js)_
 
 ## `twilio serverless:deploy`
 
@@ -95,12 +95,19 @@ USAGE
   $ twilio serverless:deploy
 
 OPTIONS
-  -n, --project-name=project-name      Overrides the name of the project. Default: the name field in your package.json
+  -n, --service-name=service-name      Overrides the name of the Serverless project. Default: the name field in your
+                                       package.json
+
   -p, --project=project                Shorthand identifier for your Twilio project.
+
   -u, --account-sid=account-sid        A specific account SID to be used for deployment. Uses fields in .env otherwise
+
   --assets                             Upload assets. Can be turned off with --no-assets
+
   --assets-folder=assets-folder        Specific folder name to be used for static assets
+
   --auth-token=auth-token              Use a specific auth token for deployment. Uses fields from .env otherwise
+
   --cwd=cwd                            Sets the directory from which to deploy
 
   --env=env                            Path to .env file. If none, the local .env in the current working directory is
@@ -114,12 +121,16 @@ OPTIONS
 
   --functions-folder=functions-folder  Specific folder name to be used for static functions
 
-  --override-existing-project          Deploys project to existing service if a naming conflict has been found.
+  --override-existing-project          Deploys Serverless project to existing service if a naming conflict has been
+                                       found.
+
+  --project-name=project-name          DEPRECATED: Overrides the name of the project. Default: the name field in your
+                                       package.json
 
   --service-sid=service-sid            SID of the Twilio Serverless service you want to deploy to.
 ```
 
-_See code: [src/commands/serverless/deploy.js](https://github.com/twilio-labs/plugin-serverless/blob/v1.0.0-alpha.7/src/commands/serverless/deploy.js)_
+_See code: [src/commands/serverless/deploy.js](https://github.com/twilio-labs/plugin-serverless/blob/v1.0.0-alpha.9/src/commands/serverless/deploy.js)_
 
 ## `twilio serverless:init NAME`
 
@@ -138,7 +149,7 @@ OPTIONS
   --auth-token=auth-token    An auth token or API secret to be used for your project
 ```
 
-_See code: [src/commands/serverless/init.js](https://github.com/twilio-labs/plugin-serverless/blob/v1.0.0-alpha.7/src/commands/serverless/init.js)_
+_See code: [src/commands/serverless/init.js](https://github.com/twilio-labs/plugin-serverless/blob/v1.0.0-alpha.9/src/commands/serverless/init.js)_
 
 ## `twilio serverless:list [TYPES]`
 
@@ -153,19 +164,32 @@ ARGUMENTS
          (services,environments,functions,assets,variables)
 
 OPTIONS
-  -n, --project-name=project-name  Overrides the name of the project. Default: the name field in your package.json
+  -n, --service-name=service-name  Overrides the name of the Serverless project. Default: the name field in your
+                                   package.json
+
   -p, --project=project            Shorthand identifier for your Twilio project.
+
   -u, --account-sid=account-sid    A specific account SID to be used for deployment. Uses fields in .env otherwise
+
   --auth-token=auth-token          Use a specific auth token for deployment. Uses fields from .env otherwise
-  --cwd=cwd                        Sets the directory of your existing Functions project. Defaults to current directory
+
+  --cwd=cwd                        Sets the directory of your existing Serverless project. Defaults to current directory
+
   --env=env                        Path to .env file for environment variables that should be installed
-  --environment=environment        The environment to list variables for
+
+  --environment=environment        [default: dev] The environment to list variables for
+
   --extended-output                Show an extended set of properties on the output
+
+  --project-name=project-name      DEPRECATED: Overrides the name of the project. Default: the name field in your
+                                   package.json
+
   --properties=properties          Specify the output properties you want to see. Works best on single types
+
   --service-sid=service-sid        Specific Serverless Service SID to run list for
 ```
 
-_See code: [src/commands/serverless/list.js](https://github.com/twilio-labs/plugin-serverless/blob/v1.0.0-alpha.7/src/commands/serverless/list.js)_
+_See code: [src/commands/serverless/list.js](https://github.com/twilio-labs/plugin-serverless/blob/v1.0.0-alpha.9/src/commands/serverless/list.js)_
 
 ## `twilio serverless:new [FILENAME]`
 
@@ -183,7 +207,7 @@ OPTIONS
   --template=template
 ```
 
-_See code: [src/commands/serverless/new.js](https://github.com/twilio-labs/plugin-serverless/blob/v1.0.0-alpha.7/src/commands/serverless/new.js)_
+_See code: [src/commands/serverless/new.js](https://github.com/twilio-labs/plugin-serverless/blob/v1.0.0-alpha.9/src/commands/serverless/new.js)_
 
 ## `twilio serverless:start [DIR]`
 
@@ -200,12 +224,22 @@ OPTIONS
   -e, --env=env              Loads .env file, overrides local env variables
   -f, --load-local-env       Includes the local environment variables
   -p, --port=port            (required) [default: 3000] Override default port of 3000
+
+  --cwd=cwd                  Alternative way to define the directory to start the server in. Overrides the [dir]
+                             argument passed.
+
   --detailed-logs            Toggles detailed request logging by showing request body and query params
+
   --inspect=inspect          Enables Node.js debugging protocol
+
   --inspect-brk=inspect-brk  Enables Node.js debugging protocol, stops executioin until debugger is attached
+
   --legacy-mode              Enables legacy mode, it will prefix your asset paths with /assets
+
   --live                     Always serve from the current functions (no caching)
+
   --logs                     Toggles request logging
+
   --ngrok=ngrok              Uses ngrok to create and outfacing url
 
 ALIASES
@@ -213,7 +247,7 @@ ALIASES
   $ twilio serverless:run
 ```
 
-_See code: [src/commands/serverless/start.js](https://github.com/twilio-labs/plugin-serverless/blob/v1.0.0-alpha.7/src/commands/serverless/start.js)_
+_See code: [src/commands/serverless/start.js](https://github.com/twilio-labs/plugin-serverless/blob/v1.0.0-alpha.9/src/commands/serverless/start.js)_
 <!-- commandsstop -->
 #  Contributing
 

--- a/bin/run
+++ b/bin/run
@@ -1,4 +1,9 @@
 #!/usr/bin/env node
+// Load up the command module *first* so that we're the parent rather than
+// some other dependency.
+const command = require('@oclif/command');
 
-require('@oclif/command').run()
-.catch(require('@oclif/errors/handle'))
+require('@twilio/cli-core').configureEnv();
+command.run()
+  .then(require('@oclif/command/flush'))
+  .catch(require('@oclif/errors/handle'));

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "@oclif/command": "^1.5.12",
     "@oclif/config": "^1.12.10",
     "@twilio/cli-core": "~1.4.1",
-    "create-twilio-function": "^1.0.1",
+    "create-twilio-function": "^2.0.0-alpha.1",
     "lodash.camelcase": "^4.3.0",
     "lodash.kebabcase": "^4.1.1",
-    "twilio-run": "^2.0.0-beta.10"
+    "twilio-run": "^2.0.0-beta.11"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.21.3",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@twilio-labs/plugin-serverless",
   "description": "Develop and deploy Twilio Serverless Functions",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.9",
   "author": "Dominik Kundel <dkundel@twilio.com>",
   "bugs": "https://github.com/twilio-labs/plugin-serverless/issues",
   "dependencies": {
     "@oclif/command": "^1.5.12",
     "@oclif/config": "^1.12.10",
-    "@twilio/cli-core": "~1.4.1",
+    "@twilio/cli-core": "^2.0.2",
     "create-twilio-function": "^2.0.0-alpha.1",
     "lodash.camelcase": "^4.3.0",
     "lodash.kebabcase": "^4.1.1",
@@ -25,14 +25,12 @@
     "globby": "^8.0.2",
     "keytar": "^4.11.0",
     "mocha": "^5.2.0",
-    "nyc": "^13.3.0",
-    "rimraf": "^2.6.3"
+    "nyc": "^13.3.0"
   },
   "engines": {
     "node": ">=8.10.0"
   },
   "files": [
-    "/npm-shrinkwrap.json",
     "/oclif.manifest.json",
     "/src",
     "/yarn.lock",
@@ -85,9 +83,9 @@
   },
   "repository": "twilio-labs/plugin-serverless",
   "scripts": {
-    "postpack": "rimraf oclif.manifest.json npm-shrinkwrap.json",
+    "postpack": "rm -f oclif.manifest.json",
     "posttest": "eslint --ignore-path .gitignore . && npm audit",
-    "prepack": "oclif-dev manifest && oclif-dev readme && npm shrinkwrap",
+    "prepack": "oclif-dev manifest && oclif-dev readme",
     "test": "nyc --check-coverage --lines 90 --reporter=html --reporter=text mocha --forbid-only \"test/**/*.test.js\"",
     "version": "oclif-dev readme && git add README.md"
   }

--- a/src/commands/serverless/init.js
+++ b/src/commands/serverless/init.js
@@ -1,8 +1,13 @@
-const { flags } = require('@oclif/command');
 const { TwilioClientCommand } = require('@twilio/cli-core').baseCommands;
-
-const createTwilioFunction = require('create-twilio-function/src/create-twilio-function');
-const { normalizeFlags } = require('../../utils');
+const {
+  handler,
+  cliInfo,
+  describe,
+} = require('create-twilio-function/src/command');
+const {
+  convertYargsOptionsToOclifFlags,
+  normalizeFlags,
+} = require('../../utils');
 
 class FunctionsInit extends TwilioClientCommand {
   constructor(argv, config, secureStorage) {
@@ -21,32 +26,26 @@ class FunctionsInit extends TwilioClientCommand {
 
     opts.path = process.cwd();
     opts.skipCredentials = true;
-    return createTwilioFunction(opts);
+    return handler(opts);
   }
 }
 
-FunctionsInit.description = 'Creates a new Twilio Serverless project';
+FunctionsInit.description = describe;
 
 FunctionsInit.args = [
   {
     name: 'name',
     required: true,
-    description:
-      'Name of Serverless project and directory that will be created',
+    description: 'Name of Serverless project and directory that will be created',
   },
 ];
 
 FunctionsInit.flags = Object.assign(
   {},
+  convertYargsOptionsToOclifFlags(cliInfo.options),
   {
-    'auth-token': flags.string({
-      description: 'An auth token or API secret to be used for your project',
-    }),
-    'account-sid': flags.string({
-      description: 'An account SID or API key to be used for your project',
-    }),
-  },
-  { project: TwilioClientCommand.flags.project }
+    project: TwilioClientCommand.flags.project,
+  }
 );
 
 module.exports = FunctionsInit;


### PR DESCRIPTION
As part of the next version of create-twilio-function the command is now exported in the '`describe`, `cliInfo`, `handler`' format. This updates the `init` command to use that instead of duplicating the options.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
