### PR TITLE
 Imports command from create-twilio-function.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@oclif/command": "^1.5.12",
     "@oclif/config": "^1.12.10",
     "@twilio/cli-core": "^2.0.2",
-    "create-twilio-function": "^1.0.1",
+    "create-twilio-function": "^2.0.0-alpha.1",
     "lodash.camelcase": "^4.3.0",
     "lodash.kebabcase": "^4.1.1",
     "twilio-run": "^2.0.0-beta.11"

--- a/src/commands/serverless/init.js
+++ b/src/commands/serverless/init.js
@@ -1,8 +1,14 @@
-const { flags } = require('@oclif/command');
 const { TwilioClientCommand } = require('@twilio/cli-core').baseCommands;
 
-const createTwilioFunction = require('create-twilio-function/src/create-twilio-function');
-const { normalizeFlags } = require('../../utils');
+const {
+  handler,
+  cliInfo,
+  describe,
+} = require('create-twilio-function/src/command');
+const {
+  convertYargsOptionsToOclifFlags,
+  normalizeFlags,
+} = require('../../utils');
 
 class FunctionsInit extends TwilioClientCommand {
   constructor(argv, config, secureStorage) {
@@ -21,31 +27,23 @@ class FunctionsInit extends TwilioClientCommand {
 
     opts.path = process.cwd();
     opts.skipCredentials = true;
-    return createTwilioFunction(opts);
+    return handler(opts);
   }
 }
 
-FunctionsInit.description = 'Creates a new Twilio Serverless project';
+FunctionsInit.description = describe;
 
 FunctionsInit.args = [
   {
     name: 'name',
     required: true,
-    description:
-      'Name of Serverless project and directory that will be created',
+    description: 'Name of Serverless project and directory that will be created',
   },
 ];
 
 FunctionsInit.flags = Object.assign(
   {},
-  {
-    'auth-token': flags.string({
-      description: 'An auth token or API secret to be used for your project',
-    }),
-    'account-sid': flags.string({
-      description: 'An account SID or API key to be used for your project',
-    }),
-  },
+  convertYargsOptionsToOclifFlags(cliInfo.options),
   { project: TwilioClientCommand.flags.project }
 );
 


### PR DESCRIPTION
As part of the next version of create-twilio-function the command is now exported in the 'describe, cliInfo, handler' format. This updates the init command to use that instead of duplicating the options.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
