### PR TITLE
fix: update to create-twilio-function 2.0.0-alpha.4 

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@oclif/command": "^1.5.12",
     "@oclif/config": "^1.12.10",
     "@twilio/cli-core": "^2.0.2",
-    "create-twilio-function": "^2.0.0-alpha.1",
+    "create-twilio-function": "^2.0.0-alpha.4",
     "lodash.camelcase": "^4.3.0",
     "lodash.kebabcase": "^4.1.1",
     "twilio-run": "^2.0.0-beta.12"


### PR DESCRIPTION
Fixes project creation.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
