### PR TITLE
feat(list-templates): exposes list-templates command from twilio-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ USAGE
 * [`twilio serverless:deploy`](#twilio-serverlessdeploy)
 * [`twilio serverless:init NAME`](#twilio-serverlessinit-name)
 * [`twilio serverless:list [TYPES]`](#twilio-serverlesslist-types)
+* [`twilio serverless:list-templates`](#twilio-serverlesslist-templates)
 * [`twilio serverless:new [NAMESPACE]`](#twilio-serverlessnew-namespace)
 * [`twilio serverless:start [DIR]`](#twilio-serverlessstart-dir)
 
@@ -154,9 +155,6 @@ OPTIONS
                                  TWILIO_AUTH_TOKEN
 
   --skip-credentials             Don't ask for Twilio account credentials or import them from the environment
-
-  --template=template            Initialize your new project with a template from
-                                 github.com/twilio-labs/function-templates
 ```
 
 _See code: [src/commands/serverless/init.js](https://github.com/twilio-labs/plugin-serverless/blob/v1.0.0-rc.3/src/commands/serverless/init.js)_
@@ -196,6 +194,17 @@ OPTIONS
 
 _See code: [src/commands/serverless/list.js](https://github.com/twilio-labs/plugin-serverless/blob/v1.0.0-rc.3/src/commands/serverless/list.js)_
 
+## `twilio serverless:list-templates`
+
+Lists the available Twilio Function templates
+
+```
+USAGE
+  $ twilio serverless:list-templates
+```
+
+_See code: [src/commands/serverless/list-templates.js](https://github.com/twilio-labs/plugin-serverless/blob/v1.0.0-rc.3/src/commands/serverless/list-templates.js)_
+
 ## `twilio serverless:new [NAMESPACE]`
 
 Creates a new Twilio Function based on an existing template
@@ -208,7 +217,6 @@ ARGUMENTS
   NAMESPACE  The namespace your assets/functions should be grouped under
 
 OPTIONS
-  -l, --list           List available templates. Will not create a new function
   --template=template
 ```
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "create-twilio-function": "^2.0.0-alpha.4",
     "lodash.camelcase": "^4.3.0",
     "lodash.kebabcase": "^4.1.1",
-    "twilio-run": "^2.0.0-rc.3"
+    "twilio-run": "^2.0.0-rc.4"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.21.3",

--- a/src/commands/serverless/list-templates.js
+++ b/src/commands/serverless/list-templates.js
@@ -1,0 +1,37 @@
+const { Command } = require('@oclif/command');
+
+const {
+  handler,
+  cliInfo,
+  describe,
+} = require('twilio-run/dist/commands/list-templates');
+const {
+  convertYargsOptionsToOclifFlags,
+  normalizeFlags,
+} = require('../../utils');
+
+class FunctionsListTemplates extends Command {
+  constructor(argv, config, secureStorage) {
+    super(argv, config, secureStorage);
+
+    this.showHeaders = true;
+  }
+
+  async run() {
+    let { flags, args } = this.parse(FunctionsListTemplates);
+    flags = normalizeFlags(flags);
+
+    const opts = Object.assign({}, flags, args);
+    return handler(opts, undefined);
+  }
+}
+
+FunctionsListTemplates.description = describe;
+
+FunctionsListTemplates.args = [];
+
+FunctionsListTemplates.flags = Object.assign(
+  convertYargsOptionsToOclifFlags(cliInfo.options)
+);
+
+module.exports = FunctionsListTemplates;


### PR DESCRIPTION
Exposes as `serverless:list-templates`.

Fixes #16 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
