### PR TITLE
feat(logs): connects up twilio-run logs command

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "create-twilio-function": "^2.1.0",
     "lodash.camelcase": "^4.3.0",
     "lodash.kebabcase": "^4.1.1",
-    "twilio-run": "^2.2.1"
+    "twilio-run": "^2.3.0"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.22.2",

--- a/src/commands/serverless/logs.js
+++ b/src/commands/serverless/logs.js
@@ -1,0 +1,34 @@
+const { TwilioClientCommand } = require('@twilio/cli-core').baseCommands;
+
+const { handler, cliInfo, describe } = require('twilio-run/dist/commands/logs');
+
+const {
+  convertYargsOptionsToOclifFlags,
+  normalizeFlags,
+  createExternalCliOptions,
+} = require('../../utils');
+
+class LogsList extends TwilioClientCommand {
+  async run() {
+    await super.run();
+
+    let { flags, args } = this.parse(LogsList);
+    flags = normalizeFlags(flags);
+
+    const externalOptions = createExternalCliOptions(flags, this.twilioClient);
+
+    const opts = Object.assign({}, flags, args);
+    return handler(opts, externalOptions);
+  }
+}
+
+LogsList.description = describe;
+
+LogsList.args = [];
+
+LogsList.flags = Object.assign(
+  convertYargsOptionsToOclifFlags(cliInfo.options),
+  { profile: TwilioClientCommand.flags.profile }
+);
+
+module.exports = LogsList;


### PR DESCRIPTION
This was modelled on the [list command](https://github.com/twilio-labs/plugin-serverless/blob/master/src/commands/serverless/list.js) and works for the basic use cases.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
